### PR TITLE
Don't suppress other completions (fixes #8, fixes #3).

### DIFF
--- a/lib/provider.coffee
+++ b/lib/provider.coffee
@@ -3,9 +3,9 @@ getCompletions = require './get-completions'
 
 module.exports =
   selector: '*'
-  inclusionPriority: 2
+  inclusionPriority: 1
   suggestionPriority: 2
-  excludeLowerPriority: true
+  excludeLowerPriority: false
   filterSuggestions: false
 
   name: 'TabNine'
@@ -16,4 +16,3 @@ module.exports =
   getSuggestions: (context) ->
     return [] unless utility.isEnabledForScope context.editor.getRootScopeDescriptor()
     getCompletions(context).catch utility.notifyError []
-


### PR DESCRIPTION
This change sets the TabNine provider's priorities to match [the snippet provider](https://github.com/atom/autocomplete-snippets/blob/2da0e23f6b4e9f8e41828700b7f9a1e737a82952/lib/snippets-provider.js#L5-L6) and permits lower-priority suggestions.

Should help with the issues folks are having. There's a risk it'll re-activate semantic completions from providers which are duplicative of TabNine's language server integrations, however.